### PR TITLE
Enable 3.7 without failing existing python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: "python"
-# workaround settings for python 3.7 on travis
-sudo: required
-dist: xenial
 
 python:
    - "2.6"
@@ -10,7 +7,10 @@ python:
    - "3.4"
    - "3.5"
    - "3.6"
+   # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
    - "3.7"
+     dist: xenial
+     sudo: true
    - "pypy"
    - "pypy3"
 


### PR DESCRIPTION
same issue mentioned here: https://github.com/travis-ci/travis-ci/issues/9831#issuecomment-418149550